### PR TITLE
feat: redirect users to account settings if profile not set

### DIFF
--- a/src/components/routes/AccountSettings.tsx
+++ b/src/components/routes/AccountSettings.tsx
@@ -28,13 +28,18 @@ import API_HOST from '../util/APIHost';
 import { client } from '../util/makeClient';
 import asAPIError from '../util/asAPIError';
 
+import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
+
 const useStyles = makeStyles(theme => ({
 	heroContent: {
-		padding: theme.spacing(14, 2, 4, 2)
+		padding: theme.spacing(8, 2, 0, 2)
 	},
 	mainContent: {
-		padding: theme.spacing(4, 2, 14, 2),
+		padding: theme.spacing(0, 2, 8, 2),
 		textAlign: 'center'
+	},
+	warning: {
+		padding: theme.spacing(4)
 	},
 	paper: {
 		padding: theme.spacing(2),
@@ -181,6 +186,14 @@ function AccountSettings({ me }: { me: APIUser }) {
 	};
 
 	return <>
+		{
+			!me.profile && <Paper elevation={2} className={classes.warning}>
+				<ErrorOutlineIcon />
+				<Typography variant="body1" color="textSecondary">
+				Before you can use UniCS  KB and meet new people, you need to finish setting up your profile below! You need to set at least your course and year of study before you can continue.
+				</Typography>
+			</Paper>
+		}
 		{<Fab variant="extended" color="primary" aria-label="save" className={classes.saveButton} disabled={!hasChanged || saveState === SaveState.Saving} onClick={updateProfile}>
 			<SaveIcon className={classes.saveIcon} />
 			Save Changes

--- a/src/components/util/ProtectedRoute.tsx
+++ b/src/components/util/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useCallback, useEffect } from 'react';
 
-import { Route, Redirect, withRouter } from 'react-router-dom';
+import { Route, Redirect, withRouter, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectJWT, selectConnected } from '../../store/slices/AuthSlice';
 import { initClientGateway, client } from './makeClient';
@@ -25,6 +25,9 @@ const ProtectedRoute = props => {
 	const connected = useSelector(selectConnected);
 	const me = useSelector(selectMe);
 	const classes = useStyles();
+	const history = useHistory();
+
+	const isAccountPage = history.location.pathname === '/account';
 
 	useEffect(() => {
 		if (!connected) initClientGateway(client);
@@ -40,7 +43,9 @@ const ProtectedRoute = props => {
 				<CircularProgress color="inherit" />
 			</Box>
 		</Backdrop>;
-	} else if (!jwt) {
+	} else if (jwt && me && !me.profile && !isAccountPage) {
+		fallback = <Redirect to="/account" />;
+	}	else if (!jwt) {
 		fallback = <Redirect to="/login" />;
 	}
 


### PR DESCRIPTION
A user's profile is basically mandatory. It isn't required during sign-up since it would be a lot of information at that point and may have put off users from registering.

This resolves #51. Any `ProtectedRoute`s will redirect to the account settings page if the user doesn't have a profile set up. A warning will also be shown at the top of the page informing the user to set up a profile.