### PR TITLE
feat: unset JWT after failed request

### DIFF
--- a/src/store/slices/ChannelsSlice.ts
+++ b/src/store/slices/ChannelsSlice.ts
@@ -14,7 +14,7 @@ const initialState: ChannelsSliceState = {
 	values: {}
 };
 
-export const fetchChannels = createAsyncThunk('channels/fetchChannels', () => client.getChannels().catch(wrapAPIError));
+export const fetchChannels = createAsyncThunk('channels/fetchChannels', (_, { dispatch }) => client.getChannels().catch(err => wrapAPIError(err, dispatch)));
 
 export const ChannelsSlice = createSlice({
 	name: 'channels',

--- a/src/store/slices/EventsSlice.ts
+++ b/src/store/slices/EventsSlice.ts
@@ -14,7 +14,7 @@ const initialState: EventsSliceState = {
 	values: {}
 };
 
-export const fetchEvents = createAsyncThunk('events/fetchEvents', () => client.getEvents().catch(wrapAPIError));
+export const fetchEvents = createAsyncThunk('events/fetchEvents', (_, { dispatch }) => client.getEvents().catch(err => wrapAPIError(err, dispatch)));
 
 export const EventsSlice = createSlice({
 	name: 'events',

--- a/src/store/slices/MessagesSlice.ts
+++ b/src/store/slices/MessagesSlice.ts
@@ -22,8 +22,8 @@ const initialState: MessagesSliceState = {
 	values: {}
 };
 
-export const fetchMessages = createAsyncThunk('messages/fetchMessages', (channelID: string) => client.getMessages(channelID).catch(wrapAPIError));
-export const createMessage = createAsyncThunk('messages/createMessage', (data: { content: string; channelID: string }) => client.createMessage(data).catch(wrapAPIError));
+export const fetchMessages = createAsyncThunk('messages/fetchMessages', (channelID: string, { dispatch }) => client.getMessages(channelID).catch(err => wrapAPIError(err, dispatch)));
+export const createMessage = createAsyncThunk('messages/createMessage', (data: { content: string; channelID: string }, { dispatch }) => client.createMessage(data).catch(err => wrapAPIError(err, dispatch)));
 
 /**
  * Inserts messages into a list of existing messages

--- a/src/store/slices/UsersSlice.ts
+++ b/src/store/slices/UsersSlice.ts
@@ -16,8 +16,8 @@ const initialState: UsersSliceState = {
 	values: {}
 };
 
-export const fetchMe = createAsyncThunk('users/fetchMe', () => client.getMe().catch(wrapAPIError));
-export const fetchUser = createAsyncThunk('users/fetchUser', (id: string) => client.getUser(id).catch(wrapAPIError));
+export const fetchMe = createAsyncThunk('users/fetchMe', (_, { dispatch }) => client.getMe().catch(err => wrapAPIError(err, dispatch)));
+export const fetchUser = createAsyncThunk('users/fetchUser', (id: string, { dispatch }) => client.getUser(id).catch(err => wrapAPIError(err, dispatch)));
 
 export const UsersSlice = createSlice({
 	name: 'users',

--- a/src/store/slices/util.ts
+++ b/src/store/slices/util.ts
@@ -1,7 +1,12 @@
+import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit';
 import asAPIError from '../../components/util/asAPIError';
+import { setJWT } from './AuthSlice';
 
-export const wrapAPIError = error => {
+export const wrapAPIError = (error: any, dispatch: ThunkDispatch<unknown, unknown, AnyAction>) => {
 	const apiError = asAPIError(error);
+	if (apiError && error?.response?.status === 401 && error?.response?.data?.error === 'Authorization token is invalid') {
+		dispatch(setJWT(null));
+	}
 	if (apiError) {
 		return Promise.reject(new Error(apiError));
 	}


### PR DESCRIPTION
This PR unsets a user's JWT if a request fails with a response that looks like it's due to the token being invalid (e.g. expired, bad token). Resolves #58.

This ends up redirecting the user to the login page again.
