### PR TITLE
fix: fetch missing data more consistently

### DIFF
--- a/src/components/routes/chat/ChatPanel.tsx
+++ b/src/components/routes/chat/ChatPanel.tsx
@@ -17,7 +17,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { fetchChannels, selectChannel } from '../../../store/slices/ChannelsSlice';
 import { APIDMChannel, APIEvent, APIEventChannel, APIUser } from '@unicsmcr/unics_social_api_client';
 import { Skeleton } from '@material-ui/lab';
-import { selectMe, selectUserById } from '../../../store/slices/UsersSlice';
+import { fetchUser, selectMe, selectUserById } from '../../../store/slices/UsersSlice';
 import { selectEvent } from '../../../store/slices/EventsSlice';
 import getIcon from '../../util/getAvatar';
 import { useParams } from 'react-router-dom';
@@ -133,6 +133,14 @@ export default function ChatPanel(props) {
 	useEffect(() => {
 		if (channelID && !channel) dispatch(fetchChannels());
 	}, [channel, channelID, dispatch]);
+
+	useEffect(() => {
+		if (me && channel && !resource) {
+			if (channel.type === 'dm') {
+				dispatch(fetchUser(channel.users.find(userID => userID !== me.id)!));
+			}
+		}
+	}, [channel, resource, me, dispatch]);
 
 	const [_infoPanelOpen, setInfoPanelOpen] = useState(false);
 	const infoPanelOpen = _infoPanelOpen || !isSmall;

--- a/src/components/util/makeClient.ts
+++ b/src/components/util/makeClient.ts
@@ -3,6 +3,7 @@ import API_HOST from './APIHost';
 import { setQueueStatus, QueueStatus, setConnected } from '../../store/slices/AuthSlice';
 import store from '../../store';
 import { addMessage, removeMessage } from '../../store/slices/MessagesSlice';
+import { fetchChannels } from '../../store/slices/ChannelsSlice';
 
 export default function makeClient() {
 	const token = localStorage.getItem('jwt');
@@ -29,6 +30,8 @@ export function initClientGateway(apiClient: APIClient) {
 	});
 	gateway.on(GatewayPacketType.MessageCreate, data => {
 		const message: APIMessage = data.message;
+		const channels = store.getState().channels;
+		if (!channels.values[message.channelID]) store.dispatch(fetchChannels());
 		store.dispatch(addMessage(message));
 	});
 	gateway.on(GatewayPacketType.MessageDelete, data => {


### PR DESCRIPTION
- If a message is received but its channel is not cached, the channel is fetched
- On mobile, users in DM channels are now fetched more consistently (doesn't require opening channel drawer)