### PR TITLE
feat: add system messages for video notifications

### DIFF
--- a/src/components/routes/chat/ChatPanel.tsx
+++ b/src/components/routes/chat/ChatPanel.tsx
@@ -114,6 +114,7 @@ const useStyles = makeStyles(theme => ({
 			right: 0,
 			bottom: 0
 		},
+		height: '100%',
 		width: `min(${DRAWER_WIDTH}, 80vw)`,
 		gridColumn: 2
 	}

--- a/src/components/routes/chat/Message.tsx
+++ b/src/components/routes/chat/Message.tsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles(theme => ({
 		'alignItems': 'center',
 		'flexDirection': 'row',
 		'fontSize': '0.8rem',
+		'lineHeight': '0.8rem',
 		'& svg': {
 			height: '0.8rem'
 		}

--- a/src/components/routes/chat/Message.tsx
+++ b/src/components/routes/chat/Message.tsx
@@ -6,10 +6,16 @@ import { darken, makeStyles } from '@material-ui/core/styles';
 import moment from 'moment';
 import { deleteMessage, OptimisedAPIMessage } from '../../../store/slices/MessagesSlice';
 
+import CallIcon from '@material-ui/icons/Call';
+import CallEndIcon from '@material-ui/icons/CallEnd';
+
 import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
 
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton } from '@material-ui/core';
 import { useDispatch } from 'react-redux';
+import SystemMessage from '../../util/SystemMessage';
+import clsx from 'clsx';
+import { green, red } from '@material-ui/core/colors';
 
 export interface MessageProps {
 	message: OptimisedAPIMessage;
@@ -34,7 +40,24 @@ const useStyles = makeStyles(theme => ({
 	time: (props: any) => ({
 		color: props.isOwn ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)',
 		marginLeft: theme.spacing(1)
-	})
+	}),
+	systemMessage: {
+		'fontWeight': 500,
+		'fontStyle': 'oblique 10deg',
+		'display': 'inline-flex',
+		'justifyContent': 'center',
+		'alignItems': 'center',
+		'flexDirection': 'row',
+		'fontSize': '0.8rem',
+		'& svg': {
+			height: '0.8rem'
+		}
+	},
+	centered: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center'
+	}
 }));
 
 export default function Message({ message, isOwn }: MessageProps) {
@@ -52,16 +75,31 @@ export default function Message({ message, isOwn }: MessageProps) {
 		setDialogOpen(false);
 	};
 
+	let content: JSX.Element|string = message.content;
+	if (content === SystemMessage.JoinVideo) {
+		content = <Box className={classes.systemMessage}>
+			<CallIcon htmlColor={green[500]} />
+			{'Joined call'}
+		</Box>;
+	} else if (content === SystemMessage.LeaveVideo) {
+		content = <Box className={classes.systemMessage}>
+			<CallEndIcon htmlColor={red[500]} />
+			{'Left call'}
+		</Box>;
+	}
+
+	const isSystem = typeof content !== 'string';
+
 	return <>
 		<Box onMouseOver={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
 			{
-				isOwn && selected && <IconButton onClick={() => setDialogOpen(true)}>
+				isOwn && selected && !isSystem && <IconButton onClick={() => setDialogOpen(true)}>
 					<DeleteOutlinedIcon />
 				</IconButton>
 			}
 			<div className={classes.messageBubble}>
-				<Typography variant="body1" style={{ textAlign: 'left' }}>
-					{ message.content }
+				<Typography variant="body1" style={{ textAlign: 'left' }} component="div" className={clsx(isSystem && classes.centered)}>
+					{ content }
 					<Typography variant="caption" className={classes.time}>{ formatTime(message.time) }</Typography>
 				</Typography>
 			</div>

--- a/src/components/routes/chat/MessagesPanel.tsx
+++ b/src/components/routes/chat/MessagesPanel.tsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectMe } from '../../../store/slices/UsersSlice';
 import { readChannel } from '../../../store/slices/ReadSlice';
 import { selectNoteByID } from '../../../store/slices/NotesSlice';
+import { SystemMessagesList } from '../../util/SystemMessage';
 
 const useStyles = makeStyles(theme => ({
 	flexGrow: {
@@ -47,6 +48,8 @@ interface MessagesPanelProps {
 		firstMessage?: string;
 	};
 }
+
+const NBSP_CHAR = String.fromCharCode(160);
 
 export default function MessagesPanel(props: MessagesPanelProps) {
 	const classes = useStyles();
@@ -145,8 +148,9 @@ export default function MessagesPanel(props: MessagesPanelProps) {
 				<form className={classes.flexGrow} onSubmit={e => {
 					e.preventDefault();
 					const form = e.target as any;
-					const message = String(new FormData(form).get('message'));
+					let message = String(new FormData(form).get('message'));
 					form.reset();
+					if (SystemMessagesList.includes(message as any)) message = `${NBSP_CHAR}${message}`;
 					dispatch(createMessage({
 						content: message,
 						channelID: props.channel.id

--- a/src/components/util/SystemMessage.ts
+++ b/src/components/util/SystemMessage.ts
@@ -1,0 +1,6 @@
+enum SystemMessage {
+	JoinVideo = '$kb_sys_msg$:join_video',
+	LeaveVideo = '$kb_sys_msg$:leave_video',
+}
+
+export default SystemMessage;

--- a/src/components/util/SystemMessage.ts
+++ b/src/components/util/SystemMessage.ts
@@ -4,3 +4,7 @@ enum SystemMessage {
 }
 
 export default SystemMessage;
+
+const SystemMessagesList = Object.values(SystemMessage);
+
+export { SystemMessagesList };


### PR DESCRIPTION
Resolves #96 

This PR adds a concept of "system messages", which are sent/received as normal messages, but they have a special content causing them to be rendered differently. Here, system messages are used to indicate when a user joins or leaves a chat call:

![image](https://user-images.githubusercontent.com/10330923/94349524-f564e500-003c-11eb-9e63-0063e6ad1f0a.png)

The user is prevented from manually typing in the system messages without modifying source code or sending manual requests (not sure why anyone would bother but it's a possibility...)