### PR TITLE
feat: better video sizing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ function AppLayer({ children }) {
 					horizontal: 'left'
 				}}
 				open={cookiesOpen}
-				message="By using this service, you agree to our cookie policy"
+				message="We make use of functional cookies"
 				action={
 					<React.Fragment>
 						<Button color="secondary" size="small" onClick={() => {

--- a/src/components/routes/chat/video/SelfVideo.tsx
+++ b/src/components/routes/chat/video/SelfVideo.tsx
@@ -12,8 +12,10 @@ const useStyles = makeStyles(theme => ({
 		position: 'absolute',
 		bottom: theme.spacing(2),
 		left: theme.spacing(2),
+		maxHeight: '15vh',
+		objectPosition: 'bottom left',
 		[theme.breakpoints.down('xs')]: {
-			width: '40vw'
+			width: '20vw'
 		}
 	}
 }));


### PR DESCRIPTION
The self-video component now has more restraints on its size to ensure it doesn't take up an obnoxious amount of space. Resolves #93

Cookie message also shortened.