### PR TITLE
feat: hide timer and video when user is blocked, show "waiting for user" in video chat

### DIFF
--- a/src/components/routes/chat/UserInfoPanel.tsx
+++ b/src/components/routes/chat/UserInfoPanel.tsx
@@ -148,7 +148,7 @@ export default function UserInfoPanel({ user, channel, onClose }: UserInfoPanelP
 			{user.forename} {user.surname}
 		</Typography>
 		{
-			hasVideo() && <Box className={classes.videoBox}>
+			hasVideo() && !isBlocked && <Box className={classes.videoBox}>
 				<Fab color={onVideoPage ? 'secondary' : 'primary'} onClick={() => {
 					onClose();
 					history.push(`${history.location.pathname.replace(/\/video/g, '')}${onVideoPage ? '' : '/video'}`);

--- a/src/components/routes/chat/video/VideoPanel.tsx
+++ b/src/components/routes/chat/video/VideoPanel.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import { APIDMChannel } from '@unicsmcr/unics_social_api_client';
@@ -17,7 +18,7 @@ interface VideoPanelProps {
 	videoJWT: string;
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
 	panel: {
 		display: 'grid',
 		height: '100%',
@@ -28,7 +29,13 @@ const useStyles = makeStyles(() => ({
 	videoArea: {
 		height: '100%',
 		width: '100%',
-		position: 'relative'
+		position: 'relative',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center'
+	},
+	waitingMessage: {
+		color: theme.palette.getContrastText('#000')
 	}
 }));
 
@@ -73,6 +80,8 @@ export default function VideoPanel(props: VideoPanelProps) {
 	const [cameraMode, setCameraMode] = useState<'user'|'environment'>('user');
 	const [tracks, setTracks] = useState<Video.LocalTrack[]>();
 
+	const [hasOtherUser, setHasOtherUser] = useState(false);
+
 	const [error, setError] = useState<string>();
 
 	const dispatch = useCallback(useDispatch(), []);
@@ -111,6 +120,7 @@ export default function VideoPanel(props: VideoPanelProps) {
 				}));
 
 				function userConnected(user: Video.Participant) {
+					setHasOtherUser(true);
 					user.on('trackSubscribed', (track: Video.AudioTrack|Video.VideoTrack) => {
 						if (peerVideoRef.current) {
 							track.attach(peerVideoRef.current);
@@ -124,6 +134,7 @@ export default function VideoPanel(props: VideoPanelProps) {
 				}
 
 				function userDisconnected() {
+					setHasOtherUser(false);
 					if (peerVideoRef.current) {
 						peerVideoRef.current.srcObject = null;
 					}
@@ -165,6 +176,9 @@ export default function VideoPanel(props: VideoPanelProps) {
 
 	return <Box className={classes.panel}>
 		<Box className={classes.videoArea}>
+			{
+				!hasOtherUser && <Typography variant="h5" className={classes.waitingMessage}>Waiting for other user...</Typography>
+			}
 			{
 				<PeerVideo ref={peerVideoRef} />
 			}


### PR DESCRIPTION
Hides the networking timer and video options when a user is blocked.

If you join a video chat and nobody else is there, you'll now see "waiting for user".

Resolves #98 