### PR TITLE
feat: add warning when websocket connection is taking a long time

### DIFF
--- a/src/components/util/ProtectedRoute.tsx
+++ b/src/components/util/ProtectedRoute.tsx
@@ -1,10 +1,10 @@
-import React, { ReactNode, useCallback, useEffect } from 'react';
+import React, { ReactNode, useCallback, useState, useEffect } from 'react';
 
-import { Route, Redirect, withRouter, useHistory } from 'react-router-dom';
+import { Route, Redirect, withRouter, useHistory, Link as RouterLink } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { selectJWT, selectConnected } from '../../store/slices/AuthSlice';
 import { initClientGateway, client } from './makeClient';
-import { makeStyles, Backdrop, CircularProgress, Typography, Box } from '@material-ui/core';
+import { makeStyles, Backdrop, CircularProgress, Typography, Box, Button, Fade } from '@material-ui/core';
 import { selectMe, fetchMe } from '../../store/slices/UsersSlice';
 import { fetchNotes, selectNotesFetched } from '../../store/slices/NotesSlice';
 
@@ -16,9 +16,40 @@ const useStyles = makeStyles(theme => ({
 		'textAlign': 'center',
 		'& > *': {
 			margin: theme.spacing(4, 0)
+		},
+		'& a': {
+			margin: theme.spacing(1, 0)
 		}
 	}
 }));
+
+const ConnectingBackdrop = () => {
+	const classes = useStyles();
+	const [showMsg, setShowMsg] = useState(false);
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			setShowMsg(true);
+		}, 8000);
+		return () => {
+			clearTimeout(timeout);
+		};
+	}, []);
+
+	return <Backdrop open={true} className={classes.backdrop}>
+		<Typography variant="h4">Connecting to UniCS KB</Typography>
+		<Box>
+			<CircularProgress color="inherit" />
+		</Box>
+		{showMsg && <Fade in>
+			<div>
+				<Typography variant="subtitle1">
+					This seems to be taking longer than usual.
+				</Typography>
+				<Button variant="contained" color="primary" component={RouterLink} to="/">Take me home</Button>
+			</div>
+		</Fade>}
+	</Backdrop>;
+};
 
 const ProtectedRoute = props => {
 	const { component: Component, ...rest } = props;
@@ -27,7 +58,6 @@ const ProtectedRoute = props => {
 	const connected = useSelector(selectConnected);
 	const me = useSelector(selectMe);
 	const haveNotes = useSelector(selectNotesFetched);
-	const classes = useStyles();
 	const history = useHistory();
 
 	const isAccountPage = history.location.pathname === '/account';
@@ -41,12 +71,7 @@ const ProtectedRoute = props => {
 
 	let fallback: ReactNode|undefined;
 	if (jwt && (!me || !connected || !haveNotes)) {
-		fallback = <Backdrop open={true} className={classes.backdrop}>
-			<Typography variant="h4">Connecting to UniCS KB</Typography>
-			<Box>
-				<CircularProgress color="inherit" />
-			</Box>
-		</Backdrop>;
+		fallback = <ConnectingBackdrop />;
 	} else if (jwt && me && !me.profile && !isAccountPage) {
 		fallback = <Redirect to="/account" />;
 	}	else if (!jwt) {


### PR DESCRIPTION
If we are unable to connect to the gateway then navigation to any pages that require it leave the user stuck looking at a loading spinner. Due to Material's `Backdrop` component taking up the whole page, there is no way for the user to navigate away without using browser navigation to go back.

This PR adds a small message that "This seems to be taking longer than usual." if we still aren't connected after 8 seconds, and gives the user a button to take them back to a known-working page (`/`).