### PR TITLE
feat: add snackbar to prompt profile completion and highlight detailed message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10847,9 +10847,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -11621,6 +11621,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
       }
     },
     "request-promise-core": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clsx": "^1.1.1",
     "match-sorter": "^5.0.0",
     "moment": "^2.28.0",
+    "qs": "^6.9.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-markdown": "^4.3.1",

--- a/src/components/routes/AccountSettings.tsx
+++ b/src/components/routes/AccountSettings.tsx
@@ -444,7 +444,7 @@ export default function AccountSettingsPage() {
 		<Page>
 			<Snackbar autoHideDuration={6000} open={snackOpen} onClose={closeSnack}>
 				<Alert severity="error" onClose={closeSnack}>
-					Please complete your profile before using chat!
+					Please complete your profile first!
 				</Alert>
 			</Snackbar>
 			{/* Hero unit */}

--- a/src/components/util/ProtectedRoute.tsx
+++ b/src/components/util/ProtectedRoute.tsx
@@ -73,7 +73,7 @@ const ProtectedRoute = props => {
 	if (jwt && (!me || !connected || !haveNotes)) {
 		fallback = <ConnectingBackdrop />;
 	} else if (jwt && me && !me.profile && !isAccountPage) {
-		fallback = <Redirect to="/account" />;
+		fallback = <Redirect to="/account?promptSetup" />;
 	}	else if (!jwt) {
 		fallback = <Redirect to="/login" />;
 	}


### PR DESCRIPTION
When clicking on "chats" or "networking" in the navigation bar on a new account it can be hard to tell why it seems like nothing happened. This PR adds a small snackbar to the profile page in this scenario prompting the user to `Please complete your profile before using chat!`. It also switches the more detailed message from `<Paper>` to an `<Alert>` to make it visually stand out on the page to ensure users notice it quickly.