### PR TITLE
feat: include networking button on empty chats page

### DIFF
--- a/src/components/routes/chat/ChatPanel.tsx
+++ b/src/components/routes/chat/ChatPanel.tsx
@@ -313,7 +313,10 @@ export default function ChatPanel(props) {
 									: <VideoPanel channel={channel as APIDMChannel} videoJWT={videoToken!} />
 							)
 							: <Box className={classes.emptyChatArea}>
-								<Typography variant="h4" color="textSecondary">Select a chat!</Typography>
+								<Box>
+									<Typography variant="h4" color="textSecondary">Select a chat!</Typography><br />
+									<Button variant="contained" color="primary" onClick={() => history.push('/networking')}>Find someone new</Button>
+								</Box>
 							</Box>
 						}
 					</Box>


### PR DESCRIPTION
Now that users are immediately taken to the chats page after logging in (assuming they've already got a profile), it would be nice to place emphasis on networking by adding a button to the networking tab:

![image](https://user-images.githubusercontent.com/10330923/101651682-3e6de800-3a35-11eb-8623-48c06b7d11d5.png)
